### PR TITLE
Lesson 4. Homework

### DIFF
--- a/kubernetes-intro/web-pod.yml
+++ b/kubernetes-intro/web-pod.yml
@@ -14,7 +14,13 @@ spec:
           mountPath: /app
   containers:
     - name: web
-      image: docker.io/neonman/otus:kubernetes-intro
+      image: neonman/otus:kubernetes-intro-8000
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 80
+      livenessProbe:
+        tcpSocket: { port: 8000 }
       volumeMounts:
         - name: app
           mountPath: /app

--- a/kubernetes-networks/canary/deployment.yml
+++ b/kubernetes-networks/canary/deployment.yml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-canary
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web-canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  template:
+    metadata:
+      name: web-canary
+      labels:
+        app: web-canary
+    spec:
+      initContainers:
+        - name: init-web
+          image: busybox:1.36
+          command: [ 'sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh' ]
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      containers:
+        - name: web-canary
+          image: neonman/otus:kubernetes-intro-8000
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: { }

--- a/kubernetes-networks/canary/ingress.yml
+++ b/kubernetes-networks/canary/ingress.yml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-canary
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "canary"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - http:
+        paths:
+          - path: /canary
+            pathType: Prefix
+            backend:
+              service:
+                name: web-canary-svc
+                port:
+                  number: 8000

--- a/kubernetes-networks/canary/service.yml
+++ b/kubernetes-networks/canary/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-canary-svc
+spec:
+  selector:
+    app: web-canary
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/coredns/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/coredns-svc-lb.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-service-tcp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "coredns-svc-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-service-udp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "coredns-svc-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ redirect;
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /dashboard(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: kubernetes-dashboard
+                port:
+                  number: 8443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels: 
+        app: web
+    spec:
+      initContainers:
+        - name: init-web
+          image: busybox:latest
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      containers:
+        - name: web
+          image: neonman/otus:kubernetes-intro-8000
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: web-svc
+                port:
+                  number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со * | DNS через MetalLB
 - [x] Задание со * | Ingress для Dashboard
 - [x] Задание со * | Canary для Ingress

## В процессе сделано:
### Работа с тестовым веб-приложением
 - Добавил readinessProbe в web-pod
 - Добавил livenessProbe в web-pod

Проверка с помощью ps aux | grep не имеет смысла, поскольку процесс будет запущен,
но сервис из-вне будет недоступен. Такая проверка имеет смысл для процессов, к которым не требуется
предоставлять сетевой доступ.

Создал манифест web-deployment.yaml скопировав в него описание из web-pod.yaml
Исправил readinessProbe на 8000 и увеличил число реплик до 3
Применил и проверил статус деплоймента:
```
$ kubectl describe deployments.apps web | grep True
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
```
### Service

Добавил и применил манифест web-svc-cip.yaml
Проверил iptables внутри minikube.

### IPVS

Включил ipvs в ConfigMap minikube
Очистил iptables
Починил резолв днс путем добавления nameserver 8.8.8.8 в файл /etc/resolv.conf
Установил пакет ipvsadm
Проверил вывод команды ipvsadm --list -n

### MetalLB

Установка:

kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
Конфигурируем metalllb ip pool не с помощью ConfigMap (deprecated в новой версии), а с помощью объекта IPAddressPool
Добавляем статический маршрут до нашего minikube:
sudo ip route add 172.17.255.0/24 via 192.168.49.2
И проверяем работу:
curl http://172.17.255.1

### Задание со * | DNS через MetalLB

Смотрим имя coredns сервиса в нашем minikube:
kubectl get svc -n kube-system
```
NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE
kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   3h53m
```
Выбираем селектор для dns-lb сервиса:
kubectl describe service kube-dns -n kube-system
```
Labels:            k8s-app=kube-dns
                   kubernetes.io/cluster-service=true
                   kubernetes.io/name=CoreDNS
```
Будем использовать селектор k8s-app: kube-dns

Создаем манифест для dns-lb сервиса согласно документации MetalLB, указав там селектор k8s-app: kube-dns
Сервисы помещаем в namespace: kube-system и применяем манифест
```
$ kubectl get svc -n kube-system 
NAME                     TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                  AGE
coredns-service-tcp-lb   LoadBalancer   10.96.191.117    172.17.255.10   53:32301/TCP             14s
coredns-service-udp-lb   LoadBalancer   10.106.196.219   172.17.255.10   53:32249/UDP             14s
kube-dns                 ClusterIP      10.96.0.10       <none>          53/UDP,53/TCP,9153/TCP   4h1m
```

### Ingress

Устанавливаем ingress-nginx согласно документации:
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.1/deploy/static/provider/baremetal/deploy.yaml

Создаем Сервис LoadBalancer nginx-lb для работы с metallb
Создаем и применяем web-svc-headless.yaml
Настраиваем ingress-прокси манифестом с ресурсом Ingress
Добавил kubernetes.io/ingress.class: nginx в аннотацию манифеста

### Задания со * | Ingress для Dashboard

Устанавливаем дашборд kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
Устанавливаем dashboard-ingress.yaml
У ingress-nginx есть проблема с загрузкой js и css с rewrite-target, поэтому используется найденное решение
https://github.com/kubernetes/ingress-nginx/issues/333#issuecomment-840066316

Создан ingress с проксированием /dashboard, пришлось добавлять сниппет для корректной работы всех ресурсов в браузере,
иначе через curl данные были, а в браузере - нет

### Задание со * | Canary для Ingress

Создал deployment и service для него, сделал ingress с canary настройками по заголовку canary: true


## Как запустить проект:
 - Применить соответствующие манифесты командой kubectl apply -f <манифест>

## Как проверить работоспособность:
 - curl http://172.17.255.1
 - curl http://172.17.255.2/web/index.html
 - nslookup ya.ru 172.17.255.10
 - открыть в локальном браузере https://172.17.255.2/dashboard/

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
